### PR TITLE
Use checked state of checkbox instead of its value

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ function App() {
 
   function handleParamChange(e) {
     const param = e.target.name
-    const value = e.target.value
+    const value = e.target.type === "checkbox" ? e.target.checked : e.target.value
     setPage(1)
     setParams(prevParams => {
       return { ...prevParams, [param]: value }


### PR DESCRIPTION
The value of a checkbox is always empty therefore the query string wouldn't include the value for `full_time`. We have to use the `checked` state instead.

(The API only filters for `full_time=true`, otherwise no filtering is happening. So requesting positions with `full_time=false` will return full time jobs as well.)